### PR TITLE
Refactor ContentTypeForm and ContentTypeList for improved

### DIFF
--- a/src/components/content-type-builder/ContentTypeForm.tsx
+++ b/src/components/content-type-builder/ContentTypeForm.tsx
@@ -82,7 +82,6 @@ export function ContentTypeForm({
       }
     }
   }
-  console.log('Rendering ContentTypeForm with fields:', fields);
 
   return (
     <div className="space-y-6">
@@ -238,19 +237,22 @@ export function ContentTypeForm({
           </div>
         ) : (
           <div className="space-y-4">
-            {Object.values(fields).map((field, index) => (
-              <FieldEditor
-                key={field.id}
-                field={field}
-                index={index}
-                onFieldChange={onFieldChange}
+            {Object.keys(fields).map((fieldId, index) => {
+              const field = fields[fieldId];
+              return (
+                <FieldEditor
+                  key={fieldId}
+                  field={field}
+                  index={index}
+                  onFieldChange={onFieldChange}
                 onRemoveField={onRemoveField}
                 draggedIndex={draggedIndex}
                 onDragStart={onDragStart}
                 onDragOver={onDragOver}
                 onDragEnd={onDragEnd}
               />
-            ))}
+            )
+          })}
           </div>
         )}
       </div>

--- a/src/components/content-type-builder/ContentTypeList.tsx
+++ b/src/components/content-type-builder/ContentTypeList.tsx
@@ -22,7 +22,6 @@ export function ContentTypeList({ onEdit, onDelete, onCreate, error }: ContentTy
   })
 
   const displayError = error || queryError?.message
-
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
@@ -46,7 +45,7 @@ export function ContentTypeList({ onEdit, onDelete, onCreate, error }: ContentTy
         </div>
       ) : contentTypes && Object.keys(contentTypes).length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {Object.entries(contentTypes).map(([uid, contentType]) => (
+          {Object.entries(contentTypes).map(([uid, contentType]) => contentType ? (
             <div key={uid} className="rounded-lg border bg-card p-6 shadow-sm hover:shadow-md transition-shadow">
               <div className="flex justify-between items-start mb-3">
                 <h3 className="text-lg font-semibold text-foreground">{contentType.displayName}</h3>
@@ -72,12 +71,12 @@ export function ContentTypeList({ onEdit, onDelete, onCreate, error }: ContentTy
                 <p className="text-sm text-muted-foreground mb-4 leading-relaxed">{contentType.description}</p>
               )}
               <div className="flex flex-wrap gap-4 text-xs text-muted-foreground pt-3 border-t">
-                <span>📋 {Object.keys(contentType.fields).length} fields</span>
+                <span>📋 {contentType.fields ? Object.keys(contentType.fields).length : 0} fields</span>
                 {contentType.options?.timestamps && <span>🕐 Timestamps</span>}
                 {contentType.options?.softDelete && <span>🗑️ Soft Delete</span>}
               </div>
             </div>
-          ))}
+          ) : '')}
         </div>
       ) : (
         <div className="text-center py-12">


### PR DESCRIPTION
This pull request refactors how fields and content types are rendered in the content type builder components, improving robustness and handling of edge cases. The changes focus on iterating over objects more safely and ensuring that empty or undefined values are handled gracefully.

**Rendering improvements and safety:**

* In `ContentTypeForm.tsx`, changed field rendering from iterating over `Object.values(fields)` to `Object.keys(fields)`, using the key both as the React element key and to access the field object. This helps prevent issues with duplicate keys and improves clarity. [[1]](diffhunk://#diff-ee9253f2afdf1e87d45e91068ed25c4b4ef3afc91bdf0a564bcd56ac2e914efeL241-R244) [[2]](diffhunk://#diff-ee9253f2afdf1e87d45e91068ed25c4b4ef3afc91bdf0a564bcd56ac2e914efeL253-R255)
* Removed an unnecessary console log statement from `ContentTypeForm.tsx` to clean up debugging output.

**Content type list robustness:**

* In `ContentTypeList.tsx`, updated rendering logic to only display content types that are defined, preventing errors when encountering undefined entries. [[1]](diffhunk://#diff-fc4a456c7487d8c72f282692f0ce42b45e989388e2e32584a0538f5fc585297fL49-R48) [[2]](diffhunk://#diff-fc4a456c7487d8c72f282692f0ce42b45e989388e2e32584a0538f5fc585297fL75-R79)
* Improved field count display by safely checking for the existence of the `fields` property before counting its keys, ensuring the UI doesn't break if `fields` is missing.
* Minor formatting cleanup by removing an unnecessary blank line for code clarity.